### PR TITLE
[docs/index]: fix github link

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -70,7 +70,7 @@
     <div id="app"></div>
     <script>
       window.$docsify = {
-        repo: 'https://github.com/eva-engine/eva.js',
+        repo: 'https://github.com/eva-engine',
         loadSidebar: true,
         loadNavbar: true,
         coverpage: true,

--- a/docs_cn/index.html
+++ b/docs_cn/index.html
@@ -70,7 +70,7 @@
     <div id="app"></div>
     <script>
       window.$docsify = {
-        repo: 'https://github.com/eva-engine/eva.js',
+        repo: 'https://github.com/eva-engine',
         loadSidebar: true,
         loadNavbar: true,
         coverpage: true,


### PR DESCRIPTION
Related issue: null



<br>

**Description**



https://github.com/eva-engine/eva.js  404 ？？？ 

Private now ?



<br>

Eh..

```diff
-    repo: 'https://github.com/eva-engine/eva.js',
+    repo: 'https://github.com/eva-engine',
```

